### PR TITLE
:zap: (halam/feature/header/#39) 메뉴가 필요없는 헤더 사용 가능하도록 기존 코드 개선

### DIFF
--- a/plinic/src/App.jsx
+++ b/plinic/src/App.jsx
@@ -34,7 +34,7 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Layout page={<Home />} fullScreen />} />
-          <Route path="/login" element={<Layout page={<Login />} />} />
+          <Route path="/login" element={<Layout noMenu page={<Login />} />} />
           <Route path="/search" element={<Layout page={<Search />} />} />
           <Route path="/post-list" element={<Layout page={<PostList />} />} />
           <Route path="/CE" element={<Layout page={<CE />} />} />

--- a/plinic/src/styles/layout/Header.jsx
+++ b/plinic/src/styles/layout/Header.jsx
@@ -5,20 +5,22 @@ import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 
-function Header() {
+function Header({ noMenu }) {
   return (
     <Wrapper>
       <LinkStyle to="/">
         <img src={'/plinic_logo.png'} height={'60px'} />
       </LinkStyle>
-      <Menu>
-        <LinkStyle to="/search">
-          <SearchIcon icon={faMagnifyingGlass} />
-        </LinkStyle>
-        <DivideLine />
-        <LinkStyle to="/login">로그인</LinkStyle>
-        <Button to="/login">회원가입</Button>
-      </Menu>
+      {noMenu || (
+        <Menu>
+          <LinkStyle to="/search">
+            <SearchIcon icon={faMagnifyingGlass} />
+          </LinkStyle>
+          <DivideLine />
+          <LinkStyle to="/login">로그인</LinkStyle>
+          <Button to="/login">회원가입</Button>
+        </Menu>
+      )}
     </Wrapper>
   );
 }

--- a/plinic/src/styles/layout/index.jsx
+++ b/plinic/src/styles/layout/index.jsx
@@ -3,13 +3,13 @@ import styled from 'styled-components';
 import Header from './Header';
 import Main from './Main';
 
-function Layout({ page, fullScreen }) {
+function Layout({ page, fullScreen, noMenu }) {
   if (fullScreen) {
     return <FullWrapper>{page}</FullWrapper>;
   } else {
     return (
       <Wrapper>
-        <Header />
+        <Header noMenu={noMenu} />
         <Main>{page}</Main>
       </Wrapper>
     );


### PR DESCRIPTION
noMenu 라는 props를 쓰면 헤더에서 메뉴가 사라지고 로고만 보이게 개선