### PR TITLE
🚧  (taeyoung/feature/search-explorepage/#68) 검색/둘러보기 페이지

### DIFF
--- a/plinic/src/App.jsx
+++ b/plinic/src/App.jsx
@@ -5,6 +5,7 @@ import {
   Home,
   Login,
   Search,
+  SearchResult,
   PostList,
   SignUp,
   CE,
@@ -37,6 +38,7 @@ function App() {
           <Route path="/" element={<Layout page={<Home />} fullScreen />} />
           <Route path="/login" element={<Layout noMenu page={<Login />} />} />
           <Route path="/search" element={<Layout page={<Search />} />} />
+          <Route path="/searchresult" element={<Layout page={<SearchResult />} />} />
           <Route path="/post-list" element={<Layout page={<PostList />} />} />
           <Route path="/sign-up" element={<Layout noMenu page={<SignUp />} />} />
           <Route path="/CE" element={<Layout page={<CE />} />} />

--- a/plinic/src/components/input/Input.jsx
+++ b/plinic/src/components/input/Input.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 
 function Input({ usedFor, userInput, setUserInput, userSubmit, setUserSubmit }) {
   const placeholder = {
@@ -8,6 +11,7 @@ function Input({ usedFor, userInput, setUserInput, userSubmit, setUserSubmit }) 
     title: '제목',
     content: '내용',
   };
+  const navigate = useNavigate();
 
   const handleInput = e => {
     setUserInput(e.target.value);
@@ -17,9 +21,14 @@ function Input({ usedFor, userInput, setUserInput, userSubmit, setUserSubmit }) 
     e.preventDefault();
   };
 
+  const navigateToResult = () => {
+    navigate('/searchresult', { state: { q: userInput } });
+  };
+
   const handleKeyDown = e => {
     if (e.key === 'Enter' && (usedFor === 'nickname' || usedFor === 'search')) {
       setUserSubmit(e.target.value);
+      navigateToResult();
     }
   };
 
@@ -33,7 +42,11 @@ function Input({ usedFor, userInput, setUserInput, userSubmit, setUserSubmit }) 
           onChange={handleInput}
           onKeyDown={handleKeyDown}
         />
-        {usedFor === 'nickname' ? <span></span> : usedFor === 'search' && <div>🔍</div>}
+        {usedFor === 'nickname' ? (
+          <span></span>
+        ) : (
+          usedFor === 'search' && <FontAwesomeIcon icon={faMagnifyingGlass} onClick={() => navigateToResult()} />
+        )}
       </FormStyled>
     </div>
   );
@@ -57,12 +70,15 @@ const FormStyled = styled.form`
     transform-origin: center;
     transition: all 0.3s;
   }
-  & > div {
-    width: 25px;
-    height: 25px;
+  & > .fa-magnifying-glass {
+    width: 18px;
+    height: 18px;
     position: absolute;
     right: 20px;
-    top: 12.5px;
+    top: 15px;
+    color: ${NAVY};
+    user-select: none;
+    cursor: pointer;
   }
 `;
 

--- a/plinic/src/pages/index.jsx
+++ b/plinic/src/pages/index.jsx
@@ -1,6 +1,6 @@
 import Home from './home/Home';
 import Login from './login/Login';
-import Search from './search/Search';
+import { Search, SearchResult } from './search';
 import PostList from './post/PostList';
 import SignUp from './sign-up/SignUp';
 import {
@@ -30,6 +30,7 @@ export {
   Home,
   Login,
   Search,
+  SearchResult,
   PostList,
   SignUp,
   CE,

--- a/plinic/src/pages/search/Search.jsx
+++ b/plinic/src/pages/search/Search.jsx
@@ -1,7 +1,38 @@
-import React from 'react';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Input from '../../components/input/Input';
+import CardCarousel from '../../components/carousel/CardCarousel';
+import { genres as data } from '../../components/carousel/genres';
 
 function Search() {
-  return <div>Search</div>;
+  const [searchInput, setSearchInput] = useState('');
+  const [searchSubmit, setSearchSubmit] = useState('');
+
+  return (
+    <Wrapper>
+      <Input
+        usedFor={'search'}
+        userInput={searchInput}
+        setUserInput={setSearchInput}
+        userSubmit={searchSubmit}
+        setUserSubmit={setSearchSubmit}
+      />
+      <ExploreWrapper>
+        <CardCarousel label={'장르'} data={data} />
+        <CardCarousel label={'분위기'} data={data} />
+      </ExploreWrapper>
+    </Wrapper>
+  );
 }
 
 export default Search;
+
+const Wrapper = styled.div`
+  ${({ theme }) => theme.align.flexCenterColumn};
+  gap: 50px;
+`;
+
+const ExploreWrapper = styled.div`
+  ${({ theme }) => theme.align.flexCenterColumn};
+  gap: 35px;
+`;

--- a/plinic/src/pages/search/SearchResult.jsx
+++ b/plinic/src/pages/search/SearchResult.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+function SearchResult() {
+  const location = useLocation();
+  const q = location.state.q;
+  return <div>"{q}"에 대한 검색 결과</div>;
+}
+
+export default SearchResult;

--- a/plinic/src/pages/search/index.jsx
+++ b/plinic/src/pages/search/index.jsx
@@ -1,0 +1,3 @@
+import Search from './Search';
+import SearchResult from './SearchResult';
+export { Search, SearchResult };


### PR DESCRIPTION
페이지에 들어가는 CardCarousel은 수정된 거 기준으로 했습니다. pr 보낸 거 머지하면 아마 바뀔..거에요..?
페이지 주소는 임의로 해서 어떤 건 `/notice/:noticeId`나 `/genre/:genretitle` 로 연결되고 어떤 건 `/searchresult` 로 연결되는데..
통일시키는 게 좋겠죠..?