### PR TITLE
🚧 (taeyoung/feature/createnoticepage/#73) 공지글 작성 페이지 퍼블리싱

### DIFF
--- a/plinic/src/components/input/Input.jsx
+++ b/plinic/src/components/input/Input.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 
-function Input({ usedFor, userInput, setUserInput, userSubmit, setUserSubmit }) {
+function Input({ usedFor, userInput, setUserInput, userSubmit, setUserSubmit, maxLength }) {
   const placeholder = {
     nickname: '닉네임',
     search: '검색어',
@@ -39,6 +39,7 @@ function Input({ usedFor, userInput, setUserInput, userSubmit, setUserSubmit }) 
           usedFor={usedFor}
           value={userInput}
           placeholder={`${placeholder[usedFor]}을 입력하세요.`}
+          maxLength={maxLength}
           onChange={handleInput}
           onKeyDown={handleKeyDown}
         />
@@ -103,16 +104,16 @@ const inputStyles = {
   `,
   title: `
   padding: 10px 12px;
-  width: 520px;
+  width: 900px;
   border: 1px solid;
   border-radius: 10px;
   `,
   content: `
   padding: 10px 12px;
-  width: 520px;
+  width: 900px;
   border: 1px solid;
   border-radius: 10px;
-  height: 150px;
+  height: 300px;
   resize: none;
   `,
 };

--- a/plinic/src/pages/notice/NoticeEdit.jsx
+++ b/plinic/src/pages/notice/NoticeEdit.jsx
@@ -1,0 +1,64 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import Input from '../../components/input/Input';
+import TextBtn from '../../components/button/text/TextBtn';
+
+function NoticeEdit() {
+  const [titleInput, setTitleInput] = useState('');
+  const [contentInput, setContentInput] = useState('');
+  const [isWarning, setIsWarning] = useState(false);
+
+  const handleUpload = () => {
+    alert(`제목: ${titleInput}\n내용: ${contentInput}`);
+  };
+
+  useEffect(() => {
+    if (titleInput.length >= 50) {
+      setIsWarning(true);
+    } else {
+      setIsWarning(false);
+    }
+  }, [titleInput]);
+
+  return (
+    <Wrapper>
+      <Title>공지글 작성하기</Title>
+      <Input usedFor={'title'} userInput={titleInput} setUserInput={setTitleInput} maxLength={50} />
+      {isWarning && <Warning>제목은 최대 50자까지 입력 가능합니다.</Warning>}
+      <Input usedFor={'content'} userInput={contentInput} setUserInput={setContentInput} />
+      <FlexRow>
+        <TextBtn location={'/'} color={'lightGreen'} btnName={'취소하기'} />
+        <TextBtn location={'/'} color={'navy'} btnName={'올리기'} onClick={handleUpload} />
+      </FlexRow>
+    </Wrapper>
+  );
+}
+
+export default NoticeEdit;
+
+const NAVY = ({ theme }) => theme.color.navy;
+
+const Wrapper = styled.div`
+  width: 80%;
+  height: 100%;
+  ${({ theme }) => theme.align.flexCenterColumn}
+  gap: 25px;
+`;
+
+const Title = styled.div`
+  margin-bottom: 20px;
+  color: ${NAVY};
+  ${({ theme }) => theme.font.size['30']};
+  ${({ theme }) => theme.font.weight['bold']};
+`;
+
+const FlexRow = styled.div`
+  width: 900px;
+  ${({ theme }) => theme.align.flexCenter}
+  justify-content: flex-end;
+  gap: 25px;
+`;
+
+const Warning = styled.div`
+  color: ${({ theme }) => theme.color.warning};
+`;


### PR DESCRIPTION
alert로 입력 값 확인 가능하게 했습니다.
제목의 경우 50자 제한을 걸어두어 50자를 넘어갈 경우 경고 문구를 Input 아래쪽에 표시되게 했습니다.
라우팅 안했습니다.