### PR TITLE
♻️ (taeyoung/refactor/cardcarousel/#88) CardCarousel 컴포넌트 개선

### DIFF
--- a/plinic/src/components/carousel/CardCarousel.jsx
+++ b/plinic/src/components/carousel/CardCarousel.jsx
@@ -112,7 +112,7 @@ function CardCarousel({ label, data, loop, detailLink }) {
       handleSwipe(direction);
     } else {
       let index = currentIndex + direction;
-      if (index > itemSize - 4 || index === 0) {
+      if (index === itemSize - 3 || index === 0) {
         return;
       } else {
         setIsTransition(true);
@@ -141,8 +141,12 @@ function CardCarousel({ label, data, loop, detailLink }) {
           )}
         </div>
         <ButtonContainer>
-          <Button onClick={isTransition ? null : () => handleOnClick(-1)}>〈</Button>
-          <Button onClick={isTransition ? null : () => handleOnClick(1)}>〉</Button>
+          <Button onClick={isTransition ? null : () => handleOnClick(-1)} disabled={currentIndex === 1}>
+            〈
+          </Button>
+          <Button onClick={isTransition ? null : () => handleOnClick(1)} disabled={currentIndex === itemSize - 4}>
+            〉
+          </Button>
         </ButtonContainer>
       </SlideHeader>
       <SlideList>
@@ -171,6 +175,7 @@ function CardCarousel({ label, data, loop, detailLink }) {
 export default CardCarousel;
 
 const NAVY = ({ theme }) => theme.color.navy;
+const DISABLED = ({ theme }) => theme.color.disabled;
 const BOLD = ({ theme }) => theme.font.weight['bold'];
 const MEDIUM_TEXT = ({ theme }) => theme.font.size['16'];
 const BOLD_TEXT = [({ theme }) => theme.font.size['30'], BOLD];
@@ -209,17 +214,17 @@ const SlideHeader = styled.div`
 const Button = styled.button`
   width: 40px;
   height: 40px;
-  margin-left: 20px;
+  margin-left: 10px;
   background: transparent;
-  border: 1px solid ${NAVY};
+  border: 1px solid ${props => (props.disabled ? DISABLED : NAVY)};
   border-radius: 20px;
   text-align: center;
   line-height: 40px;
   text-decoration: none;
-  color: ${NAVY};
+  color: ${props => (props.disabled ? DISABLED : NAVY)};
   ${MEDIUM_TEXT};
   ${BOLD};
-  cursor: pointer;
+  cursor: ${props => props.disabled || 'pointer'};
 `;
 
 const ButtonContainer = styled.div`

--- a/plinic/src/components/carousel/CardCarousel.jsx
+++ b/plinic/src/components/carousel/CardCarousel.jsx
@@ -1,18 +1,59 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowRightLong, faMusic } from '@fortawesome/free-solid-svg-icons';
 import Thumbnail from '../thumbnail/Thumbnail';
+import Post from '../post/Post';
 
-function CardCarousel({ label, data }) {
+function CardCarousel({ label, data, loop, detailLink }) {
   const items = data;
   const itemSize = items.length;
   const addedItems = 10;
-  let slides = setSlides();
-  const [currentIndex, setCurrentIndex] = useState(10);
+  let slides = loop ? setSlides() : items;
+  const [currentIndex, setCurrentIndex] = useState(loop ? 10 : 1);
   const [slideTransition, setTransition] = useState('');
   const [isTransition, setIsTransition] = useState(false);
   const transitionTime = 300;
   const transitionStyle = `transform ${transitionTime}ms ease 0s`;
+
+  const explore = (genre, img) => {
+    return (
+      <Link to={`/explore/${genre}`}>
+        <Thumbnail img={img} />
+        <DimThumbnail />
+        <Label>{genre}</Label>
+      </Link>
+    );
+  };
+
+  const searchResult = (label, slide) => {
+    let type = label === '유저' ? 'user' : 'post';
+
+    return (
+      <Link to={`/${type}/${slide.id}`}>
+        {type === 'user' ? (
+          <User>
+            <UserProfile image={slide.profile_pic} />
+            <div>
+              <UserNickname>{slide.nickname}</UserNickname>
+              <div>
+                <FontAwesomeIcon icon={faMusic} /> {slide.playlists}
+              </div>
+            </div>
+          </User>
+        ) : (
+          <Post
+            thumbnail={slide.thumbnail}
+            title={slide.title}
+            writer={slide.writer}
+            likes={slide.like}
+            likeState={slide.likeState}
+          />
+        )}
+      </Link>
+    );
+  };
 
   function setSlides() {
     let addedFront = [];
@@ -66,8 +107,19 @@ function CardCarousel({ label, data }) {
   }
 
   function handleOnClick(direction) {
-    setIsTransition(true);
-    handleSwipe(direction);
+    if (loop) {
+      setIsTransition(true);
+      handleSwipe(direction);
+    } else {
+      let index = currentIndex + direction;
+      if (index > itemSize - 4 || index === 0) {
+        return;
+      } else {
+        setIsTransition(true);
+        setCurrentIndex(index);
+        setTransition(transitionStyle);
+      }
+    }
   }
 
   function handleTransitionEnd() {
@@ -77,7 +129,17 @@ function CardCarousel({ label, data }) {
   return (
     <SlideBox>
       <SlideHeader>
-        <div>{label} 둘러보기</div>
+        <div>
+          <div>
+            {label}
+            {(label === '장르' || label === '분위기') && ' 둘러보기'}
+          </div>
+          {!(label === '장르' || label === '분위기') && (
+            <Link to={detailLink}>
+              더보기 <FontAwesomeIcon icon={faArrowRightLong} />
+            </Link>
+          )}
+        </div>
         <ButtonContainer>
           <Button onClick={isTransition ? null : () => handleOnClick(-1)}>〈</Button>
           <Button onClick={isTransition ? null : () => handleOnClick(1)}>〉</Button>
@@ -87,7 +149,7 @@ function CardCarousel({ label, data }) {
         <SlideTrack
           onTransitionEnd={handleTransitionEnd}
           style={{
-            transform: `translateX(${-247 * (currentIndex + 1)}px)`,
+            transform: `translateX(${-247 * (currentIndex - 1)}px)`,
             transition: slideTransition,
           }}
         >
@@ -96,11 +158,7 @@ function CardCarousel({ label, data }) {
             const [genre, img] = getSlideItem(itemIndex);
             return (
               <SlideItem key={slideIndex}>
-                <Link to={`/explore/${genre}`}>
-                  <Thumbnail img={img} />
-                  <DimThumbnail />
-                  <Label>{genre}</Label>
-                </Link>
+                {label === '장르' || label === '분위기' ? explore(genre, img) : searchResult(label, slide)}
               </SlideItem>
             );
           })}
@@ -131,7 +189,21 @@ const SlideHeader = styled.div`
   display: flex;
   justify-content: space-between;
   color: ${NAVY};
-  ${BOLD_TEXT};
+
+  & > div {
+    ${CENTER};
+    justify-content: flex-start;
+    gap: 20px;
+
+    & > div:first-child {
+      ${BOLD_TEXT};
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+  }
 `;
 
 const Button = styled.button`
@@ -170,6 +242,11 @@ const SlideItem = styled.div`
   position: relative;
   ${CENTER_COLUMN}
   cursor: pointer;
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 `;
 
 const DimThumbnail = styled.div`
@@ -192,4 +269,37 @@ const Label = styled.div`
   ${({ theme }) => theme.font.size['20']};
   color: ${({ theme }) => theme.color.white};
   z-index: 10;
+`;
+
+const User = styled.div`
+  width: 222px;
+  height: fit-content;
+  ${CENTER_COLUMN};
+  gap: 20px;
+
+  & > div:last-child {
+    ${CENTER_COLUMN};
+    gap: 10px;
+
+    & > div:last-child {
+      ${CENTER};
+      align-items: flex-start;
+      ${({ theme }) => theme.font.size['16']};
+      line-height: 18px;
+      color: #555;
+      gap: 8px;
+    }
+  }
+`;
+
+const UserProfile = styled.div`
+  background-color: gray;
+  /* background: url(${props => props.image}) no-repeat center/cover; */
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+`;
+
+const UserNickname = styled.div`
+  ${({ theme }) => theme.font.size['20']};
 `;

--- a/plinic/src/components/carousel/CardCarousel.jsx
+++ b/plinic/src/components/carousel/CardCarousel.jsx
@@ -141,10 +141,13 @@ function CardCarousel({ label, data, loop, detailLink }) {
           )}
         </div>
         <ButtonContainer>
-          <Button onClick={isTransition ? null : () => handleOnClick(-1)} disabled={currentIndex === 1}>
+          <Button onClick={isTransition ? null : () => handleOnClick(-1)} disabled={!loop && currentIndex === 1}>
             〈
           </Button>
-          <Button onClick={isTransition ? null : () => handleOnClick(1)} disabled={currentIndex === itemSize - 4}>
+          <Button
+            onClick={isTransition ? null : () => handleOnClick(1)}
+            disabled={!loop && currentIndex === itemSize - 4}
+          >
             〉
           </Button>
         </ButtonContainer>
@@ -153,7 +156,7 @@ function CardCarousel({ label, data, loop, detailLink }) {
         <SlideTrack
           onTransitionEnd={handleTransitionEnd}
           style={{
-            transform: `translateX(${-247 * (currentIndex - 1)}px)`,
+            transform: `translateX(${-242 * (currentIndex - 1)}px)`,
             transition: slideTransition,
           }}
         >
@@ -232,14 +235,14 @@ const ButtonContainer = styled.div`
 `;
 
 const SlideList = styled.div`
-  width: calc(222px * 5 + 100px);
+  width: calc(222px * 5 + 85px);
   overflow: hidden;
 `;
 
 const SlideTrack = styled.div`
   display: flex;
   align-items: center;
-  gap: 25px;
+  gap: 20px;
   width: fit-content;
 `;
 

--- a/plinic/src/pages/search/Search.jsx
+++ b/plinic/src/pages/search/Search.jsx
@@ -18,8 +18,8 @@ function Search() {
         setUserSubmit={setSearchSubmit}
       />
       <ExploreWrapper>
-        <CardCarousel label={'장르'} data={data} />
-        <CardCarousel label={'분위기'} data={data} />
+        <CardCarousel label={'장르'} data={data} loop={true} />
+        <CardCarousel label={'분위기'} data={data} loop={true} />
       </ExploreWrapper>
     </Wrapper>
   );

--- a/plinic/src/pages/test/ty/TestCardCarousel.jsx
+++ b/plinic/src/pages/test/ty/TestCardCarousel.jsx
@@ -4,7 +4,7 @@ import { genres } from '../../../components/carousel/genres';
 
 function TestCardCarousel() {
   const data = genres;
-  return <CardCarousel label={'장르'} data={data} />;
+  return <CardCarousel label={'게시글'} data={data} loop={false} detailLink={'/'} />;
 }
 
 export default TestCardCarousel;


### PR DESCRIPTION
검색 페이지에서 사용하기 위해 수정했습니다.
props로 총 4가지를 받습니다.
- `label`: 슬라이드 위쪽에 표시되는 단어로, `['장르', '분위기', '유저', '게시글']` 리스트 안 아이템(문자열)에 대응합니다.
- `data`: 슬라이드에 표시할 데이터입니다.
  - 장르/분위기: 썸네일, 장르 또는 분위기 텍스트
  - 유저: 프로필 사진, 닉네임, 플레이리스트 수
  - 게시글: 썸네일, 제목, 작성자, 좋아요 수, 사용자가 해당 게시글을 좋아요 한 여부
- `loop`: 무한으로 반복할 것인가를 판단하는 불리언 값
- `datailLink`: 더보기 버튼 클릭 시 연결되는 페이지로, 유저 혹은 게시글 데이터 사용 시 필요합니다.
  - 유저나 게시글 검색 상세 페이지로 이동해야 합니다. (ex. `/search-detail/user?q=어쩌구`)
> 수정하다 보니 조금 난잡해졌지만... 어떻게든 돌아가긴 해서 일단 pr 보내요..