### PR TITLE
:bug::lipstick: (halam/fix/layout header issue/#87) 레이아웃 깨짐 현상 해결

### DIFF
--- a/plinic/src/styles/layout/Header.jsx
+++ b/plinic/src/styles/layout/Header.jsx
@@ -55,6 +55,9 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  background-color: white;
+  z-index: 100000;
+  position: relative;
 `;
 
 const Menu = styled.div`

--- a/plinic/src/styles/layout/Main.jsx
+++ b/plinic/src/styles/layout/Main.jsx
@@ -12,7 +12,6 @@ const FLEX_CENTER_COLUMN = ({ theme }) => theme.align.flexCenterColumn;
 const Wrapper = styled.div`
   width: 100%;
   height: calc(100vh - 60px);
-  ${FLEX_CENTER_COLUMN};
-  overflow: hidden;
+
   /* background-color: ${({ theme }) => theme.color.navy}; */
 `;


### PR DESCRIPTION
요소가 헤더 위로 올라가는 현상 해결
- Main Layout에서 정렬하지 않도록 수정
- Header 가 위로 올라가도록 스타일 수정