### PR TITLE
:bulb: (halam/deploy/#141) Mixed content 오류 해결 코드 주석 처리

### DIFF
--- a/plinic/public/index.html
+++ b/plinic/public/index.html
@@ -11,7 +11,9 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
     <title>React App</title>
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+
+    <!-- Mixed content 에러를 해결하기 위한 코드였으나 로컬에서 개발할 때는 오히려 이 줄 때문에 에러가 나기 때문에 주석 처리함. -->
+    <!-- <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" /> -->
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
배포 환경에서 생기는 오류인 Mixed content 를 해결하기 위해 index.html 에 코드를 넣었으나, 로컬 환경에서는 이 코드 때문에 문제가 되기 때문에 주석처리했습니다.