### PR TITLE
:bug: (halam/fix/profile-edit-page/#154) 프로필 편집 페이지 오류 해결 

### DIFF
--- a/plinic/src/components/button/genre/GenreList.jsx
+++ b/plinic/src/components/button/genre/GenreList.jsx
@@ -15,10 +15,12 @@ function GenreList(props) {
     key.push(genre.name);
   }
 
-  if (key.includes(props.isClicked)) {
-    props.setIsHere(true);
-  } else {
-    props.setIsHere(false);
+  if (props.setIsHere) {
+    if (key.includes(props.isClicked)) {
+      props.setIsHere(true);
+    } else {
+      props.setIsHere(false);
+    }
   }
 
   return (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87893624/197021500-3b173118-1156-43b4-a914-d52f136fe8ab.png)

장르 리스트 컴포넌트에서 프로필 편집 페이지에서 사용하지 않는 props 함수를 사용하기 때문에 오류난 것이었음.
이를 해결하기 위해 장르 리스트 컴포넌트에서 문제되는 props의 존재 여부를 확인하는 조건문을 만들고, 그 안에서 동작하도록 수정.